### PR TITLE
Fix typo in esbuild option name

### DIFF
--- a/src/_compile.js
+++ b/src/_compile.js
@@ -92,7 +92,7 @@ async function compileHandler (params) {
 
   // Final config check
   let localConfig = getTsConfig(src)
-  /**/ if (localConfig) options.tsConfig = localConfig
+  /**/ if (localConfig) options.tsconfig = localConfig
   else if (globalTsConfig) options.tsconfig = globalTsConfig
 
   // Run the build


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!

---

This resolves

```
✘ [ERROR] Invalid option in build() call: "tsConfig"

    /Users/ian/Documents/wizard/node_modules/@architect/plugin-typescript/node_modules/esbuild/lib/main.js:253:12:
      253 │       throw new Error(`Invalid option ${where}: ${quote(key)}`);
          ╵             ^

    at checkForInvalidFlags (/Users/ian/Documents/wizard/node_modules/@architect/plugin-typescript/node_modules/esbuild/lib/main.js:253:13)
    at flagsForBuildOptions (/Users/ian/Documents/wizard/node_modules/@architect/plugin-typescript/node_modules/esbuild/lib/main.js:458:3)
    at buildOrServeContinue (/Users/ian/Documents/wizard/node_modules/@architect/plugin-typescript/node_modules/esbuild/lib/main.js:1013:9)
    at buildOrServeImpl (/Users/ian/Documents/wizard/node_modules/@architect/plugin-typescript/node_modules/esbuild/lib/main.js:996:5)
    at Object.buildOrServe (/Users/ian/Documents/wizard/node_modules/@architect/plugin-typescript/node_modules/esbuild/lib/main.js:777:5)
    at /Users/ian/Documents/wizard/node_modules/@architect/plugin-typescript/node_modules/esbuild/lib/main.js:2116:17
    at new Promise (<anonymous>)
    at Object.build (/Users/ian/Documents/wizard/node_modules/@architect/plugin-typescript/node_modules/esbuild/lib/main.js:2115:14)
    at build (/Users/ian/Documents/wizard/node_modules/@architect/plugin-typescript/node_modules/esbuild/lib/main.js:1962:51)
    at compileHandler (/Users/ian/Documents/wizard/node_modules/@architect/plugin-typescript/src/_compile.js:99:9)
```

when using a `tsconfig` file located in an Architect subproject. Indeed, `tsConfig` is not a valid option name listed [here](https://github.com/evanw/esbuild/blob/v0.16.8/lib/shared/common.ts). I'm unsure why I wasn't seeing this problem before the esbuild version update, though.