### PR TITLE
Add handlers for non http types

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@architect/architect": "^11.0.2",
     "@architect/eslint-config": "^2.1.2",
-    "@architect/functions": "^8.0.3",
     "@types/node": "^20.11.19",
     "cross-env": "^7.0.3",
     "eslint": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,14 @@
   "devDependencies": {
     "@architect/architect": "^11.0.2",
     "@architect/eslint-config": "^2.1.2",
+    "@architect/functions": "^8.0.3",
+    "@types/node": "^20.11.19",
     "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "tap-arc": "^1.2.2",
     "tape": "^5.7.4",
-    "tiny-json-http": "^7.5.1"
+    "tiny-json-http": "^7.5.1",
+    "typescript": "^5.3.3"
   },
   "eslintConfig": {
     "extends": "@architect/eslint-config"

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ import { Context, APIGatewayProxyResult, APIGatewayEvent } from 'aws-lambda'
 export const handler = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> => {
   console.log(`Event:`, event)
   console.log(`Context:`, context)
-  return { message: 'hello world' }
+  return { statusCode: 200, body: JSON.stringify({ message: 'Hello world!' }) }
 }
 ```
 

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -3,7 +3,7 @@ const httpHandlerBody = `import { Context, APIGatewayProxyResult, APIGatewayEven
 export const handler = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> => {
   console.log('Event:', event)
   console.log('Context:', context)
-  return { message: 'Hello world!' }
+  return { statusCode: 200, body: JSON.stringify({ message: 'Hello world!' }) }
 }`
 
 const sqsHandlerBody = `import { Context, SQSBatchResponse, SQSEvent } from 'aws-lambda'

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -1,0 +1,45 @@
+const httpHandlerBody = `import { Context, APIGatewayProxyResult, APIGatewayEvent } from 'aws-lambda'
+
+export const handler = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> => {
+  console.log('Event:', event)
+  console.log('Context:', context)
+  return { message: 'Hello world!' }
+}`
+
+const sqsHandlerBody = `import { Context, SQSBatchResponse, SQSEvent } from 'aws-lambda'
+
+export const handler = async (event: SQSEvent, context: Context): Promise<SQSBatchResponse> => {
+    console.log('Event:', event)
+    console.log('Context:', context)
+    return { batchItemFailures: [] }
+}`
+
+const snsHandlerBody = `import { Context, SNSEvent } from 'aws-lambda'
+
+export const handler = async (event: SNSEvent, context: Context) => {
+    console.log('Event:', event)
+    console.log('Context:', context)
+}`
+
+const scheduledHandlerBody = `import { Context, ScheduledEvent } from 'aws-lambda'
+
+export const handler = async (event: ScheduledEvent, context: Context) => {
+    console.log('Event:', event)
+    console.log('Context:', context)
+}`
+
+const dynamoDbStreamHandlerBody = `import { Context, DynamoDBBatchResponse, DynamoDBStreamEvent } from 'aws-lambda'
+
+export const handler = async (event: DynamoDBStreamEvent, context: Context): Promise<DynamoDBBatchResponse> => {
+    console.log('Event:', event)
+    console.log('Context:', context)
+    return { batchItemFailures: [] }
+}`
+
+module.exports = {
+  httpHandlerBody,
+  sqsHandlerBody,
+  snsHandlerBody,
+  scheduledHandlerBody,
+  dynamoDbStreamHandlerBody,
+}

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -36,10 +36,19 @@ export const handler = async (event: DynamoDBStreamEvent, context: Context): Pro
     return { batchItemFailures: [] }
 }`
 
+const websocketHandlerBody = `import { Context, APIGatewayProxyResultV2, APIGatewayProxyWebsocketEventV2 } from 'aws-lambda'
+
+export const handler = async (event: APIGatewayProxyWebsocketEventV2, context: Context): Promise<APIGatewayProxyResultV2> => {
+  console.log('Event:', event)
+  console.log('Context:', context)
+  return { statusCode: 200 }
+}`
+
 module.exports = {
   httpHandlerBody,
   sqsHandlerBody,
   snsHandlerBody,
   scheduledHandlerBody,
   dynamoDbStreamHandlerBody,
+  websocketHandlerBody
 }

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -44,11 +44,22 @@ export const handler = async (event: APIGatewayProxyWebsocketEventV2, context: C
   return { statusCode: 200 }
 }`
 
-module.exports = {
-  httpHandlerBody,
-  sqsHandlerBody,
-  snsHandlerBody,
-  scheduledHandlerBody,
-  dynamoDbStreamHandlerBody,
-  websocketHandlerBody
+
+const customLambdaHandler = `import { Handler } from 'aws-lambda'
+
+export const handler: Handler = async (event, context) => {
+  console.log('Event:', event)
+  console.log('Context:', context)
+}`
+
+const pragmaHandlerMap = {
+  'http': httpHandlerBody,
+  'ws': websocketHandlerBody,
+  'queues': sqsHandlerBody,
+  'events': snsHandlerBody,
+  'scheduled': scheduledHandlerBody,
+  'table-streams': dynamoDbStreamHandlerBody,
+  'custom': customLambdaHandler
 }
+
+module.exports = pragmaHandlerMap

--- a/src/index.js
+++ b/src/index.js
@@ -4,14 +4,7 @@ let {
   getTsConfig,
 } = require('./_compile')
 
-let {
-  dynamoDbStreamHandlerBody,
-  httpHandlerBody,
-  sqsHandlerBody,
-  snsHandlerBody,
-  scheduledHandlerBody,
-  websocketHandlerBody
-} = require('./handlers')
+let handlers = require('./handlers')
 
 module.exports = {
   set: {
@@ -38,29 +31,7 @@ module.exports = {
   },
   create: {
     handlers: ({ lambda: { pragma } }) => {
-      let body
-      switch (pragma) {
-      case 'http':
-        body = httpHandlerBody
-        break
-      case 'queues':
-        body = sqsHandlerBody
-        break
-      case 'events':
-        body = snsHandlerBody
-        break
-      case 'scheduled':
-        body = scheduledHandlerBody
-        break
-      case 'tables-streams':
-        body = dynamoDbStreamHandlerBody
-        break
-      case 'ws':
-        body = websocketHandlerBody
-        break
-      default:
-        throw Error(`Unknown lambda type: ${pragma}`)
-      }
+      let body = handlers[pragma] ?? handlers.custom
       return { filename: 'index.ts', body }
     }
   },

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ let {
   sqsHandlerBody,
   snsHandlerBody,
   scheduledHandlerBody,
+  websocketHandlerBody
 } = require('./handlers')
 
 module.exports = {
@@ -53,6 +54,9 @@ module.exports = {
         break
       case 'tables-streams':
         body = dynamoDbStreamHandlerBody
+        break
+      case 'ws':
+        body = websocketHandlerBody
         break
       default:
         throw Error(`Unknown lambda type: ${pragma}`)

--- a/test/integration/project-test.js
+++ b/test/integration/project-test.js
@@ -8,7 +8,7 @@ let sandbox = require('@architect/sandbox')
 let port = 6666
 let mock = join(process.cwd(), 'test', 'mock')
 let cwd, build, newHandler, queueHandler, eventHandler
-  , scheduledHandler, tableStreamHandler
+  , scheduledHandler, tableStreamHandler, customHandler
   , wsConnect, wsDisconnect, wsHandler, wsNew
 let url = path => `http://localhost:${port}/${path}`
 let banner = /lolidk/
@@ -23,6 +23,7 @@ function reset () {
   rmSync(wsConnect, { recursive: true, force: true })
   rmSync(wsDisconnect, { recursive: true, force: true })
   rmSync(wsNew, { recursive: true, force: true })
+  rmSync(customHandler, { recursive: true, force: true })
   rmSync(build, { recursive: true, force: true })
 }
 
@@ -62,6 +63,7 @@ test('Start Sandbox (default project)', async t => {
   wsConnect = join(cwd, 'src', 'ws', 'connect')
   wsDisconnect = join(cwd, 'src', 'ws', 'disconnect')
   wsNew = join(cwd, 'src', 'ws', 'ws-new')
+  customHandler = join(cwd, 'src', 'custom')
   build = join(cwd, '.build')
   reset()
   await sandbox.start({ cwd, port, quiet: true })
@@ -104,6 +106,13 @@ test('Table Stream Handler typechecks', async t => {
   t.plan(1)
   let typecheckErros = checkTypeScriptFile(tableStreamHandler + '/index.ts')
   t.ok(typecheckErros, 'Table Stream handler typechecks')
+})
+
+
+test('Custom Handler typechecks', async t => {
+  t.plan(1)
+  let typecheckErros = checkTypeScriptFile(customHandler + '/index.ts')
+  t.ok(typecheckErros, 'Custom handler typechecks')
 })
 
 test('WS Handlers typecheck', async t => {

--- a/test/integration/project-test.js
+++ b/test/integration/project-test.js
@@ -2,17 +2,42 @@ let { join } = require('path')
 let { existsSync, readFileSync, rmSync } = require('fs')
 let test = require('tape')
 let { get } = require('tiny-json-http')
+let ts = require('typescript')
 let sandbox = require('@architect/sandbox')
 
 let port = 6666
 let mock = join(process.cwd(), 'test', 'mock')
-let cwd, build, newHandler
+let cwd, build, newHandler, queueHandler, eventHandler, scheduledHandler, tableStreamHandler
 let url = path => `http://localhost:${port}/${path}`
 let banner = /lolidk/
 
 function reset () {
   rmSync(newHandler, { recursive: true, force: true })
+  rmSync(queueHandler, { recursive: true, force: true })
+  rmSync(eventHandler, { recursive: true, force: true })
+  rmSync(scheduledHandler, { recursive: true, force: true })
+  rmSync(tableStreamHandler, { recursive: true, force: true })
   rmSync(build, { recursive: true, force: true })
+}
+
+function checkTypeScriptFile (filePath) {
+  const program = ts.createProgram([ filePath ], {
+    noEmit: true, // Don't generate output files
+    skipLibCheck: false, // Skip type checking of default library declaration files,
+  })
+  const emitResult = program.emit()
+  const allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics)
+
+  let hasErrors = false
+  allDiagnostics.forEach((diagnostic) => {
+    if (diagnostic.category === ts.DiagnosticCategory.Error) {
+      hasErrors = true
+      const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+      console.error(`Error in ${filePath}: ${message}`)
+    }
+  })
+
+  return !hasErrors
 }
 
 /**
@@ -23,13 +48,17 @@ test('Start Sandbox (default project)', async t => {
   t.plan(1)
   cwd = join(mock, 'defaults')
   newHandler = join(cwd, 'src', 'http', 'get-new')
+  queueHandler = join(cwd, 'src', 'queues', 'queue-new')
+  eventHandler = join(cwd, 'src', 'events', 'event-new')
+  scheduledHandler = join(cwd, 'src', 'scheduled', 'scheduled-new')
+  tableStreamHandler = join(cwd, 'src', 'tables-streams', 'table-stream-new')
   build = join(cwd, '.build')
   reset()
   await sandbox.start({ cwd, port, quiet: true })
   t.pass('Started Sandbox')
 })
 
-test('Handler transpiled', async t => {
+test('HTTP Handler transpiled', async t => {
   t.plan(4)
   let result = await get({ url: url('ok') })
   t.deepEqual(result.body, { ok: true }, 'Transpiled handler returned correct body')
@@ -40,6 +69,31 @@ test('Handler transpiled', async t => {
   let lines = handler.split('\n').filter(Boolean).length
   t.ok(lines > 1, `Handler is not minified: ${lines} lines`)
   t.doesNotMatch(handler, banner, 'Handler does not have custom banner')
+})
+
+test('Queue Handler typechecks', async t => {
+  t.plan(1)
+  let typecheckErros = checkTypeScriptFile(queueHandler + '/index.ts')
+  t.ok(typecheckErros, 'Queue handler typechecks')
+})
+
+
+test('Event Handler typechecks', async t => {
+  t.plan(1)
+  let typecheckErros = checkTypeScriptFile(eventHandler + '/index.ts')
+  t.ok(typecheckErros, 'Event handler typechecks')
+})
+
+test('Scheduled Handler typechecks', async t => {
+  t.plan(1)
+  let typecheckErros = checkTypeScriptFile(scheduledHandler + '/index.ts')
+  t.ok(typecheckErros, 'Scheduled handler typechecks')
+})
+
+test('Table Stream Handler typechecks', async t => {
+  t.plan(1)
+  let typecheckErros = checkTypeScriptFile(tableStreamHandler + '/index.ts')
+  t.ok(typecheckErros, 'Table Stream handler typechecks')
 })
 
 test('Sourcemap support', async t => {
@@ -62,9 +116,11 @@ test('Sourcemap support', async t => {
 })
 
 test('Handler created', async t => {
-  t.plan(1)
+  t.plan(2)
+  let typecheckErros = checkTypeScriptFile(join(cwd, 'src', 'http', 'get-new', 'index.ts'))
+  t.ok(typecheckErros, 'HTTP handler typechecks')
   let result = await get({ url: url('new') })
-  t.deepEqual(result.body, { message: 'Hello world!' }, 'Freshly created and transpiled handler returned correct body')
+  t.deepEqual(JSON.parse(result.body), { message: 'Hello world!' }, 'Freshly created and transpiled handler returned correct body')
 })
 
 test('Shut down Sandbox', async t => {

--- a/test/integration/project-test.js
+++ b/test/integration/project-test.js
@@ -7,7 +7,9 @@ let sandbox = require('@architect/sandbox')
 
 let port = 6666
 let mock = join(process.cwd(), 'test', 'mock')
-let cwd, build, newHandler, queueHandler, eventHandler, scheduledHandler, tableStreamHandler
+let cwd, build, newHandler, queueHandler, eventHandler
+  , scheduledHandler, tableStreamHandler
+  , wsConnect, wsDisconnect, wsHandler, wsNew
 let url = path => `http://localhost:${port}/${path}`
 let banner = /lolidk/
 
@@ -17,6 +19,10 @@ function reset () {
   rmSync(eventHandler, { recursive: true, force: true })
   rmSync(scheduledHandler, { recursive: true, force: true })
   rmSync(tableStreamHandler, { recursive: true, force: true })
+  rmSync(wsHandler, { recursive: true, force: true })
+  rmSync(wsConnect, { recursive: true, force: true })
+  rmSync(wsDisconnect, { recursive: true, force: true })
+  rmSync(wsNew, { recursive: true, force: true })
   rmSync(build, { recursive: true, force: true })
 }
 
@@ -52,6 +58,10 @@ test('Start Sandbox (default project)', async t => {
   eventHandler = join(cwd, 'src', 'events', 'event-new')
   scheduledHandler = join(cwd, 'src', 'scheduled', 'scheduled-new')
   tableStreamHandler = join(cwd, 'src', 'tables-streams', 'table-stream-new')
+  wsHandler = join(cwd, 'src', 'ws', 'default')
+  wsConnect = join(cwd, 'src', 'ws', 'connect')
+  wsDisconnect = join(cwd, 'src', 'ws', 'disconnect')
+  wsNew = join(cwd, 'src', 'ws', 'ws-new')
   build = join(cwd, '.build')
   reset()
   await sandbox.start({ cwd, port, quiet: true })
@@ -94,6 +104,15 @@ test('Table Stream Handler typechecks', async t => {
   t.plan(1)
   let typecheckErros = checkTypeScriptFile(tableStreamHandler + '/index.ts')
   t.ok(typecheckErros, 'Table Stream handler typechecks')
+})
+
+test('WS Handlers typecheck', async t => {
+  t.plan(4)
+  let handlers = [ wsHandler, wsConnect, wsDisconnect, wsNew ]
+  handlers.forEach(handler => {
+    let typecheckErros = checkTypeScriptFile(handler + '/index.ts')
+    t.ok(typecheckErros, 'WS handler typechecks')
+  })
 })
 
 test('Sourcemap support', async t => {

--- a/test/mock/defaults/app.arc
+++ b/test/mock/defaults/app.arc
@@ -12,3 +12,19 @@ get /new
 @plugins
 architect/plugin-typescript
   src ../../..
+
+@tables
+table-stream-new
+  pk *String
+
+@queues
+queue-new
+
+@events
+event-new
+
+@tables-streams
+table-stream-new
+
+@scheduled
+scheduled-new rate(1 day)

--- a/test/mock/defaults/app.arc
+++ b/test/mock/defaults/app.arc
@@ -28,3 +28,6 @@ table-stream-new
 
 @scheduled
 scheduled-new rate(1 day)
+
+@ws
+ws-new

--- a/test/mock/defaults/app.arc
+++ b/test/mock/defaults/app.arc
@@ -12,6 +12,8 @@ get /new
 @plugins
 architect/plugin-typescript
   src ../../..
+custom-lambda-plugin
+  src ./src/custom-lambda-plugin
 
 @tables
 table-stream-new

--- a/test/mock/defaults/src/custom-lambda-plugin/index.js
+++ b/test/mock/defaults/src/custom-lambda-plugin/index.js
@@ -1,0 +1,8 @@
+module.exports = { set: {
+    customLambdas: ({ arc, inventory }) => {
+      return {
+        name: 'custom-lambda-new',
+        src: __dirname + '/../custom' // Points to a handler dir inside the plugin
+      }
+    }
+  } }


### PR DESCRIPTION
Hi,

I've added some additional handler templates for SQS, SNS, Scheduled events, table streams and ws.

These are a bit difficult to test as they are async and not request/response, so I've added `typescript` as a dev dependency and I typecheck the generated code to make sure it will at least build.

Let me know if you have any improvements. Im happy to fix anything up.

Love the @architect project btw. Just discovered it last week!

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from ~`master`~ `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
